### PR TITLE
Removing DATA_FOLDER comment

### DIFF
--- a/ob.cfg
+++ b/ob.cfg
@@ -1,6 +1,6 @@
 [CONSTANTS]
 
-#DATA_FOLDER = /path/to/OpenBazaar/
+DATA_FOLDER = /path/to/OpenBazaar/
 
 KSIZE = 20
 ALPHA = 3


### PR DESCRIPTION
Did a reinstall and couldn't get the server to start without removing this comment. 

